### PR TITLE
Add mechanism for *.local overrides; .gitignore those files (fixes #8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ html/
 O.*/
 cdCommands
 envPaths
+**/configure/*.local
 
 # Backup and temp files
 *~

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -32,4 +32,18 @@ CROSS_COMPILER_TARGET_ARCHS =
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
-UASDK = $(TOP)/../../uasdkcppclient-src-debian7.7-x86_64-gcc4.7.2-v1.5.3-346/sdk
+#UASDK = $(TOP)/../../uasdkcppclient-src-debian7.7-x86_64-gcc4.7.2-v1.5.3-346/sdk
+
+# When developing against a public or shared repo:
+#   Do not edit the settings in this file!
+#
+# You may create a file CONFIG_SITE.local pointing to your
+# local settings, e.g.
+#   UASDK = /home/install/UA-SDK/1.5.3/sdk
+
+# Configuration "above the TOP" for all modules in that place
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/../configure/CONFIG_SITE.local
+
+# The definition in this directory always overrides
+-include $(TOP)/configure/CONFIG_SITE.local

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -22,3 +22,17 @@
 ## EPICS_BASE usually appears last so other apps can override stuff:
 
 EPICS_BASE=$(TOP)/../../BASE
+
+# When developing against a public or shared repo:
+#   Do not edit the locations in this file!
+#
+# You may create a file RELEASE.local pointing to your location
+# of EPICS_BASE, e.g.
+#   EPICS_BASE = /home/install/epics/base
+
+# Configuration "above the TOP" for all modules in that place
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../configure/RELEASE.local
+
+# The definition in this directory always overrides
+-include $(TOP)/configure/RELEASE.local

--- a/testTop/configure/CONFIG_SITE
+++ b/testTop/configure/CONFIG_SITE
@@ -32,4 +32,22 @@ CROSS_COMPILER_TARGET_ARCHS =
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
-UASDK = $(TOP)/../../../uasdkcppclient-src-debian7.7-x86_64-gcc4.7.2-v1.5.3-346/sdk
+# When developing against a public or shared repo:
+#   Do not edit the settings in this file!
+#
+# You may create a file CONFIG_SITE.local pointing to your
+# local settings, e.g.
+#   CROSS_COMPILER_TARGET_ARCHS = RTEMS-mvme5500
+
+# Inside an embedded TOP, use the following definitions
+# pointing to the configuration of the parent module
+-include $(TOP)/../../CONFIG_SITE.local
+-include $(TOP)/../../configure/CONFIG_SITE.local
+-include $(TOP)/../configure/CONFIG_SITE.local
+
+# Inside a standalone TOP, use the following definitions instead
+#-include $(TOP)/../CONFIG_SITE.local
+#-include $(TOP)/../configure/CONFIG_SITE.local
+
+# The definition in this directory always overrides
+-include $(TOP)/configure/CONFIG_SITE.local

--- a/testTop/configure/RELEASE
+++ b/testTop/configure/RELEASE
@@ -21,6 +21,23 @@
 
 OPCUA=$(TOP)/..
 
-# EPICS_BASE usually appears last so other apps can override stuff:
+# When developing against a public or shared repo:
+#   Do not edit the locations in this file!
+#
+# You may create a file RELEASE.local pointing to your locations
+# of the OPCUA device support and EPICS_BASE, e.g.
+#   OPCUA = /home/install/epics/opcua
+#   EPICS_BASE = /home/install/epics/base
+#
+# Inside an embedded TOP, use the following definitions
+# pointing to the configuration of the parent module
+-include $(TOP)/../../RELEASE.local
+-include $(TOP)/../../configure/RELEASE.local
+-include $(TOP)/../configure/RELEASE.local
 
-EPICS_BASE=$(TOP)/../../../BASE
+# Inside a standalone TOP, use the following definitions instead
+#-include $(TOP)/../RELEASE.local
+#-include $(TOP)/../configure/RELEASE.local
+
+# The definition in this directory always overrides
+-include $(TOP)/configure/RELEASE.local


### PR DESCRIPTION
Add the necessary includes to the build system files to use *.local overrides for `RELEASE` and `CONFIG_SITE`.