### PR TITLE
Use standard locations for *.local overrides; .gitignore them (fixes #8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ html/
 O.*/
 cdCommands
 envPaths
-#**/configure/*.local
+**/configure/*.local
 
 # Backup and temp files
 *~

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # opcUaUnifiedAutomation
 
-EPICS opcUa device support with Unified Automation C++ based [client sdk] (https://www.unified-automation.com/products/client-sdk.html).
-
-## Installation
-
-* Depending on your linux installation, install *libcrypto*
-
-To prevent local settings from being traced by git create your local configuration 
-files. They will be ignored by git:
-
-* Create file *configure/RELEASE.local* and set *EPICS_BASE* variable to your EPICS installation.
-
-* Create file *configure/CONFIG_SITE.local* and set *UASDK* variable to your UA-SDK installation.
+EPICS opcUa device support with Unified Automation C++ based
+[client sdk](https://www.unified-automation.com/products/client-sdk.html).
 
 
-```
-**/configure/*.local
-```
+## Build and Installation
+
+* This module has a standard EPICS module structure. It compiles against
+  recent versions of EPICS Base 3.14, 3.15 and 3.16.
+
+* Depending on your Linux installation, install *libcrypto*.
+
+* When cloning this module, you may create local settings that are not being
+  traced by git.
+
+  * Create *configure/RELEASE.local* and set *EPICS_BASE* to point to your
+    EPICS installation.
+
+  * Create *configure/CONFIG_SITE.local* and set *UASDK* to point to your
+    Unified Automation OPC UA C++ Client SDK installation.
+
 
 ## Features
-
 
 * Data conversion for all integer and float data types. Data loss may occur for
   conversion from float to integer types and from long to short integer types.

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -13,26 +13,34 @@
 # Normally CHECK_RELEASE should be set to YES.
 # Set CHECK_RELEASE to NO to disable checking completely.
 # Set CHECK_RELEASE to WARN to perform consistency checking but
-#   continue building anyway if conflicts are found.
+#   continue building even if conflicts are found.
 CHECK_RELEASE = YES
 
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.
-#INSTALL_LOCATION=</path/name/to/install/top>
+#INSTALL_LOCATION=</absolute/path/to/install/top>
 
-# Set this when your IOC and the host use different paths
-#   to access the application. This will be needed to boot
-#   from a Microsoft FTP server or with some NFS mounts.
-# You must rebuild in the iocBoot directory for this to
-#   take effect.
-#IOCS_APPL_TOP = </IOC/path/to/application/top>
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
 
-# UASDK = $(TOP)/../../uasdkcppclient-v1.5.3-346/sdk
-# to keep local configuration outside git control define UASDK local
-include $(TOP)/configure/CONFIG_SITE.local
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
 
+# Path to the Unified Automation OPC UA C++ SDK
+#UASDK = $(TOP)/../../uasdkcppclient-v1.5.3-346/sdk
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/../configure/CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -14,13 +14,27 @@
 #  RELEASE.Common.$(T_A)
 #  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 #
-# This file should ONLY define paths to other support modules,
-# or include statements that pull in similar RELEASE files.
-# Build settings that are NOT module paths should appear in a
-# CONFIG_SITE file.
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it can ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
 
-## EPICS_BASE usually appears last so other apps can override stuff:
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
 
-#EPICS_BASE=$(TOP)/../../BASE
-# to keep local configuration outside git control define BASE and whatelse local
-include $(TOP)/configure/RELEASE.local
+# EPICS_BASE should appear last so earlier modules can override stuff:
+#EPICS_BASE = $(TOP)/../../BASE
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These allow developers to override the RELEASE variable settings
+# without having to modify the configure/RELEASE file itself.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../configure/RELEASE.local
+-include $(TOP)/configure/RELEASE.local

--- a/testTop/configure/CONFIG_SITE
+++ b/testTop/configure/CONFIG_SITE
@@ -13,25 +13,40 @@
 # Normally CHECK_RELEASE should be set to YES.
 # Set CHECK_RELEASE to NO to disable checking completely.
 # Set CHECK_RELEASE to WARN to perform consistency checking but
-#   continue building anyway if conflicts are found.
+#   continue building even if conflicts are found.
 CHECK_RELEASE = YES
 
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.
-#INSTALL_LOCATION=</path/name/to/install/top>
+#INSTALL_LOCATION=</absolute/path/to/install/top>
 
-# Set this when your IOC and the host use different paths
-#   to access the application. This will be needed to boot
-#   from a Microsoft FTP server or with some NFS mounts.
-# You must rebuild in the iocBoot directory for this to
-#   take effect.
-#IOCS_APPL_TOP = </IOC/path/to/application/top>
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
 
-#UASDK = $(TOP)/../../../uasdkcppclient-v1.5.3-346/sdk
-# to keep local configuration outside git control define UASDK local
-include $(TOP)/configure/CONFIG_SITE.local
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+
+# Inside an embedded TOP, use the following definitions
+# pointing to the configuration of the parent module
+-include $(TOP)/../../CONFIG_SITE.local
+-include $(TOP)/../../configure/CONFIG_SITE.local
+-include $(TOP)/../configure/CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+
+# Inside a standalone TOP, use the following definitions instead
+#-include $(TOP)/../CONFIG_SITE.local
+#-include $(TOP)/../configure/CONFIG_SITE.local
+#-include $(TOP)/configure/CONFIG_SITE.local

--- a/testTop/configure/RELEASE
+++ b/testTop/configure/RELEASE
@@ -14,15 +14,38 @@
 #  RELEASE.Common.$(T_A)
 #  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 #
-# This file should ONLY define paths to other support modules,
-# or include statements that pull in similar RELEASE files.
-# Build settings that are NOT module paths should appear in a
-# CONFIG_SITE file.
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it can ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
 
 OPCUA=$(TOP)/..
 
-# EPICS_BASE usually appears last so other apps can override stuff:
+# EPICS_BASE should appear last so earlier modules can override stuff:
+#EPICS_BASE = $(OPCUA)/../../BASE
 
-#EPICS_BASE=$(TOP)/../../../BASE
-# to keep local configuration outside git control define BASE and whatelse local
-include $(TOP)/configure/RELEASE.local
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These allow developers to override the RELEASE variable settings
+# without having to modify the configure/RELEASE file itself.
+
+# Inside an embedded TOP, use the following definitions
+# pointing to the configuration of the parent module
+-include $(TOP)/../../RELEASE.local
+-include $(TOP)/../../configure/RELEASE.local
+-include $(TOP)/../configure/RELEASE.local
+-include $(TOP)/configure/RELEASE.local
+
+# Inside a standalone TOP, use the following definitions instead
+#-include $(TOP)/../RELEASE.local
+#-include $(TOP)/../configure/RELEASE.local
+#-include $(TOP)/configure/RELEASE.local


### PR DESCRIPTION
I'm proposing (again) to use the full set of locations for *.local overrides.

These changes are making the configuration files as close as possible to the files that are created using `makeBaseApp.pl` from the EPICS Base template.

It is perfectly fine to only mention one of the configuration options in the README and only use that option. However, please do not break a standard mechanism from Base for others that are using it.

(And please discuss a proposal before turning it down.)