### PR TITLE
Fix handling updates with 'Uncertain' status

### DIFF
--- a/opcUaDevSupApp/devUaSubscription.cpp
+++ b/opcUaDevSupApp/devUaSubscription.cpp
@@ -61,7 +61,7 @@ void DevUaSubscription::dataChange(
         OPCUA_ItemINFO* pOPCUA_ItemINFO = m_vectorUaItemInfo->at(dataNotifications[i].ClientHandle);
         try {
             epicsMutexLock(pOPCUA_ItemINFO->flagLock);
-            if (! OpcUa_IsGood(dataNotifications[i].Value.StatusCode) )
+            if (OpcUa_IsBad(dataNotifications[i].Value.StatusCode) )
             {
                 if(pOPCUA_ItemINFO->debug>= 2) errlogPrintf("  Variable %d failed with status %s\n", dataNotifications[i].ClientHandle,
                        UaStatus(dataNotifications[i].Value.StatusCode).toString().toUtf8());


### PR DESCRIPTION
This fixes issues with variables from a WinCC OA server never updating because of their 'Uncertain' status. (In this case: UncertainInitialValue.)

Basically, in the context of data updates, 'Uncertain' is now being treated the same as 'Good'.
See #14 for a suggestion of how to interface status properly.