### PR TITLE
Fix external SDK library handling (fixes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ EPICS opcUa device support with Unified Automation C++ based
 * This module has a standard EPICS module structure. It compiles against
   recent versions of EPICS Base 3.14, 3.15 and 3.16.
 
-* Depending on your Linux installation, install *libcrypto*.
-
 * When cloning this module, you may create local settings that are not being
   traced by git.
 
@@ -19,6 +17,9 @@ EPICS opcUa device support with Unified Automation C++ based
 
   * Create *configure/CONFIG_SITE.local* and set *UASDK* to point to your
     Unified Automation OPC UA C++ Client SDK installation.
+
+* Building binaries (IOCs) may need libcrypto installed, depending on the
+  setup used when compiling the SDK libraries.
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -8,10 +8,21 @@ EPICS opcUa device support with Unified Automation C++ based
 * Unified Automation C++ Based OPC UA Client SDK.
   This device support has been developed using the 1.5.x series.
 
-* Building binaries (IOCs) needs libcrypto and libxml2 on your system.
-  Package names depend on the Linux distribution:
-  openssl-devel and libxml2-devel on RedHat/CentOS/Fedora,
-  libssl-dev and libxml2-dev on Debian/Ubuntu.
+* If you want to use crypto support (authentication/encryption), you need
+  libcrypto on your system - both when compiling the SDK and when generating
+  any binaries (IOCs).
+  The name of the package you have to install depends on the Linux distro:
+  openssl-devel on RedHat/CentOS/Fedora, libssl-dev on Debian/Ubuntu.
+  Use the CONFIG_SITE.local file (see below) where the binary is created
+  to set this option.
+
+* If you want support for XML definitions (e.g. for using the SDK examples
+  and tools), you need libxml2 an your system - both when compiling the SDK
+  and when generating any binaries (IOCs).
+  The name of the package you have to install depends on the Linux distro:
+  libxml2-devel on RedHat/CentOS/Fedora, libxml2-dev on Debian/Ubuntu.
+  Use the CONFIG_SITE.local file (see below) where the binary is created
+  to set this option.
 
 ## Build and Installation
 
@@ -26,8 +37,8 @@ EPICS opcUa device support with Unified Automation C++ based
 
   * Create *configure/CONFIG_SITE.local* and set *UASDK* to point to your
     Unified Automation C++ OPC UA Client SDK installation.
-    This is also where you select how the SDK libraries are installed on your
-    target systems.
+    This is also where you select how the SDK libraries will be installed
+    on your target systems, and the optional support choices (see above).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -3,24 +3,31 @@
 EPICS opcUa device support with Unified Automation C++ based
 [client sdk](https://www.unified-automation.com/products/client-sdk.html).
 
+## Prerequisites
+
+* Unified Automation C++ Based OPC UA Client SDK.
+  This device support has been developed using the 1.5.x series.
+
+* Building binaries (IOCs) needs libcrypto and libxml2 on your system.
+  Package names depend on the Linux distribution:
+  openssl-devel and libxml2-devel on RedHat/CentOS/Fedora,
+  libssl-dev and libxml2-dev on Debian/Ubuntu.
 
 ## Build and Installation
 
 * This module has a standard EPICS module structure. It compiles against
   recent versions of EPICS Base 3.14, 3.15 and 3.16.
 
-* When cloning this module, you may create local settings that are not being
-  traced by git.
+* When cloning this module from the repository, you may create local settings
+  that are not being traced by git and don't create conflicts:
 
   * Create *configure/RELEASE.local* and set *EPICS_BASE* to point to your
     EPICS installation.
 
   * Create *configure/CONFIG_SITE.local* and set *UASDK* to point to your
-    Unified Automation OPC UA C++ Client SDK installation.
-
-* Building binaries (IOCs) may need libcrypto installed, depending on the
-  setup used when compiling the SDK libraries.
-
+    Unified Automation C++ OPC UA Client SDK installation.
+    This is also where you select how the SDK libraries are installed on your
+    target systems.
 
 ## Features
 

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -38,6 +38,13 @@ CHECK_RELEASE = YES
 # Path to the Unified Automation OPC UA C++ SDK
 #UASDK = $(TOP)/../../uasdkcppclient-v1.5.3-346/sdk
 
+# How the Unified Automation SDK shared libraries are deployed
+#   SYSTEM = shared libs are in a system location
+#   PROVIDED = shared libs are in $(UASDK_DIR)
+#   INSTALL = shared libs are installed (copied) into this module
+UASDK_DEPLOY_MODE = SYSTEM
+UASDK_DIR = $(UASDK)/lib
+
 # These allow developers to override the CONFIG_SITE variable
 # settings without having to modify the configure/CONFIG_SITE
 # file itself.

--- a/opcUaDevSupApp/Makefile
+++ b/opcUaDevSupApp/Makefile
@@ -9,9 +9,6 @@ LIBRARY_HOST += opcUa
 opcUa_SRCS = devOpcUa.c drvOpcUa.cpp devUaSubscription.cpp
 INC += devOpcUa.h drvOpcUa.h
 
-USR_SYS_LIBS += crypto
-USR_SYS_LIBS += xml2
-
 UASDK_LIBS = uabase uaclient uapki uastack xmlparser
 
 USR_INCLUDES += $(foreach module, $(UASDK_LIBS), -I$(UASDK)/include/$(module))

--- a/opcUaDevSupApp/Makefile
+++ b/opcUaDevSupApp/Makefile
@@ -3,49 +3,54 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 
-#------------------------generic definitions----------------------#
-
-CROSS_COMPILER_TARGET_ARCHS=
-
-STATIC_BUILD = NO
-
 DBD = opcUa.dbd
 
 LIBRARY_HOST += opcUa
 opcUa_SRCS = devOpcUa.c drvOpcUa.cpp devUaSubscription.cpp
 INC += devOpcUa.h drvOpcUa.h
-###
 
 USR_SYS_LIBS += crypto
 USR_SYS_LIBS += xml2
 
-uastack_DIR=$(UASDK)/lib
-USR_LIBS += uastack
+UASDK_LIBS = uabase uaclient uapki uastack xmlparser
 
-USR_INCLUDES += -I$(UASDK)/include/uabase
-USR_INCLUDES += -I$(UASDK)/include/uaclient
-USR_INCLUDES += -I$(UASDK)/include/uapki
-USR_INCLUDES += -I$(UASDK)/include/uastack
-USR_INCLUDES += -I$(UASDK)/include/xmlparser
+USR_INCLUDES += $(foreach module, $(UASDK_LIBS), -I$(UASDK)/include/$(module))
 
-EXTLIB_INSTALLS += $(INSTALL_LIB)/libuastack.so
+ifeq ($(UASDK_DEPLOY_MODE),SYSTEM)
+USR_SYS_LIBS += $(UASDK_LIBS)
+endif
 
-opcUa_DIR = $(UASDK)/lib
-opcUa_LIBS += uaclient
-opcUa_LIBS += uapki
-opcUa_LIBS += uabase
-opcUa_LIBS += xmlparser
+ifeq ($(UASDK_DEPLOY_MODE),PROVIDED)
+define UA_template
+  USR_LIBS += $(1)
+  $(1)_DIR = $(UASDK_DIR)
+endef
+$(foreach lib, $(UASDK_LIBS), $(eval $(call UA_template,$(lib))))
+endif
+
+ifeq ($(UASDK_DEPLOY_MODE),INSTALL)
+EXTLIB_INSTALLS += $(addprefix $(INSTALL_LIB)/, \
+    $(notdir $(wildcard $(foreach lib, $(UASDK_LIBS), \
+    $(UASDK_DIR)/$(LIB_PREFIX)$(lib)$(LIB_SUFFIX) ))))
+    ifeq ($(SHARED_LIBRARIES),YES)
+EXTLIB_INSTALLS += $(addprefix $(INSTALL_LIB)/, \
+    $(notdir $(wildcard $(foreach lib, $(UASDK_LIBS), \
+    $(UASDK_DIR)/$(SHRLIB_PREFIX)$(lib)$(SHRLIB_SUFFIX) ))))
+    endif
+endif
 
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
 
+ifeq ($(UASDK_DEPLOY_MODE),INSTALL)
 build: $(EXTLIB_INSTALLS)
 
-$(INSTALL_LIB)/lib%.a : $(UASDK)/lib/lib%.a
-	$(ECHO) "Installing $@, $<"
+$(INSTALL_LIB)/$(LIB_PREFIX)%$(LIB_SUFFIX) : $(UASDK_DIR)/$(LIB_PREFIX)%$(LIB_SUFFIX)
+	$(ECHO) "Installing library $@ from Unified Automation SDK"
 	$(INSTALL) -d -m 444 $< $(@D)
 
-$(INSTALL_LIB)/lib%.so : $(UASDK)/lib/lib%.so
-	$(ECHO) "Installing $@, $<"
+$(INSTALL_LIB)/$(SHRLIB_PREFIX)%$(SHRLIB_SUFFIX) : $(UASDK_DIR)/$(SHRLIB_PREFIX)%$(SHRLIB_SUFFIX)
+	$(ECHO) "Installing shared library $@ from Unified Automation SDK"
 	$(INSTALL) -d -m 555 $< $(@D)
+endif

--- a/testTop/clientApp/Makefile
+++ b/testTop/clientApp/Makefile
@@ -3,34 +3,19 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 
-#------------------------generic definitions----------------------#
-
-CROSS_COMPILER_TARGET_ARCHS=
-
-STATIC_BUILD = NO
-
 PROD = opcUaClient
 PROD_SRCS = clientMain.cpp
 
-opcUaClient_DIR = $(UASDK)/lib
 opcUaClient_LIBS += opcUa
+opcUaClient_LIBS += $(UASDK_LIBS)
 opcUaClient_LIBS += $(EPICS_BASE_IOC_LIBS)
-opcUaClient_LIBS += uastack
-opcUaClient_LIBS += uaclient
-opcUaClient_LIBS += uapki
-opcUaClient_LIBS += uabase
-opcUaClient_LIBS += xmlparser
 
-USR_INCLUDES += -I$(UASDK)/include/uabase
-USR_INCLUDES += -I$(UASDK)/include/uaclient
-USR_INCLUDES += -I$(UASDK)/include/uapki
-USR_INCLUDES += -I$(UASDK)/include/uastack
-USR_INCLUDES += -I$(UASDK)/include/xmlparser
-
-# set rpath than the libraries can be found at your install location
-# check path with: 'readelf -d ../bin/linux-x86_64/opcUcClient'
-#
-#USR_LDFLAGS += '-Wl,-rpath,/home/kuner/tmp/testUa'
+ifeq ($(UASDK_DEPLOY_MODE),PROVIDED)
+define UA_template
+  $(1)_DIR = $(UASDK_DIR)
+endef
+$(foreach lib, $(UASDK_LIBS), $(eval $(call UA_template,$(lib))))
+endif
 
 include $(TOP)/configure/RULES
 #----------------------------------------

--- a/testTop/clientApp/Makefile
+++ b/testTop/clientApp/Makefile
@@ -10,7 +10,13 @@ PROD_LIBS += opcUa
 PROD_LIBS += $(UASDK_LIBS)
 PROD_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-PROD_SYS_LIBS += xml2 crypto
+ifeq ($(UASDK_USE_XMLPARSER),YES)
+PROD_SYS_LIBS += xml2
+endif
+
+ifeq ($(UASDK_USE_CRYPTO),YES)
+PROD_SYS_LIBS += crypto
+endif
 
 ifeq ($(UASDK_DEPLOY_MODE),PROVIDED)
 define UA_template

--- a/testTop/clientApp/Makefile
+++ b/testTop/clientApp/Makefile
@@ -6,9 +6,11 @@ include $(TOP)/configure/CONFIG
 PROD = opcUaClient
 PROD_SRCS = clientMain.cpp
 
-opcUaClient_LIBS += opcUa
-opcUaClient_LIBS += $(UASDK_LIBS)
-opcUaClient_LIBS += $(EPICS_BASE_IOC_LIBS)
+PROD_LIBS += opcUa
+PROD_LIBS += $(UASDK_LIBS)
+PROD_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+PROD_SYS_LIBS += xml2 crypto
 
 ifeq ($(UASDK_DEPLOY_MODE),PROVIDED)
 define UA_template

--- a/testTop/clientApp/clientMain.cpp
+++ b/testTop/clientApp/clientMain.cpp
@@ -138,6 +138,7 @@ OPCUA_ItemINFO * newOpcItem(char *path,int verb)
     if(strlen(path) < ITEMPATHLEN) {
         strcpy(pOPCUA_ItemINFO->ItemPath,path);
         addOPCUA_Item(pOPCUA_ItemINFO);
+        return pOPCUA_ItemINFO;
     }
     free(pOPCUA_ItemINFO);
     printf("Skip Argument '%s'\n",path);

--- a/testTop/configure/CONFIG_SITE
+++ b/testTop/configure/CONFIG_SITE
@@ -45,7 +45,7 @@ CHECK_RELEASE = YES
 UASDK_DEPLOY_MODE = SYSTEM
 UASDK_DIR = $(UASDK)/lib
 
-UASDK_LIBS = uabase uaclient uapki uastack xmlparser
+UASDK_LIBS = uaclient uapki uabase uastack xmlparser
 USR_INCLUDES += $(foreach lib, $(UASDK_LIBS), -I$(UASDK)/include/$(lib))
 
 # These allow developers to override the CONFIG_SITE variable

--- a/testTop/configure/CONFIG_SITE
+++ b/testTop/configure/CONFIG_SITE
@@ -35,6 +35,19 @@ CHECK_RELEASE = YES
 #HOST_OPT = NO
 #CROSS_OPT = NO
 
+# Path to the Unified Automation OPC UA C++ SDK
+#UASDK = $(TOP)/../../uasdkcppclient-v1.5.3-346/sdk
+
+# How the Unified Automation SDK shared libraries are deployed
+#   SYSTEM = shared libs are in a system location
+#   PROVIDED = shared libs are in $(UASDK_DIR)
+#   INSTALL = shared libs are installed (copied) into this module
+UASDK_DEPLOY_MODE = SYSTEM
+UASDK_DIR = $(UASDK)/lib
+
+UASDK_LIBS = uabase uaclient uapki uastack xmlparser
+USR_INCLUDES += $(foreach lib, $(UASDK_LIBS), -I$(UASDK)/include/$(lib))
+
 # These allow developers to override the CONFIG_SITE variable
 # settings without having to modify the configure/CONFIG_SITE
 # file itself.

--- a/testTop/configure/CONFIG_SITE
+++ b/testTop/configure/CONFIG_SITE
@@ -44,8 +44,14 @@ CHECK_RELEASE = YES
 #   INSTALL = shared libs are installed (copied) into this module
 UASDK_DEPLOY_MODE = SYSTEM
 UASDK_DIR = $(UASDK)/lib
+# How the Unified Automation SDK libraries were built
+UASDK_USE_CRYPTO = YES
+UASDK_USE_XMLPARSER = YES
 
-UASDK_LIBS = uaclient uapki uabase uastack xmlparser
+UASDK_LIBS = uaclient uapki uabase uastack
+ifeq ($UASDK_USE_XMLPARSER),YES)
+UASDK_LIBS += xmlparser
+endif
 USR_INCLUDES += $(foreach lib, $(UASDK_LIBS), -I$(UASDK)/include/$(lib))
 
 # These allow developers to override the CONFIG_SITE variable

--- a/testTop/testIocApp/Makefile
+++ b/testTop/testIocApp/Makefile
@@ -3,15 +3,9 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 
-#------------------------generic definitions----------------------#
-
-CROSS_COMPILER_TARGET_ARCHS=
-
-STATIC_BUILD = NO
-
 DB = testServer.db freeopcuaTEST.db
 
-IOCS+= OPCUAIOC
+IOCS += OPCUAIOC
 
 PROD_IOC = $(IOCS)
 DBD = $(IOCS:%=%.dbd)
@@ -21,6 +15,13 @@ $(ioc)_SRCS += $(ioc)_registerRecordDeviceDriver.cpp SoftIocMain.cpp
 endef
 
 $(foreach ioc,$(PROD_IOC),$(eval $(RRDD)))
+
+ifeq ($(UASDK_DEPLOY_MODE),PROVIDED)
+define UA_template
+  $(1)_DIR = $(UASDK_DIR)
+endef
+$(foreach lib, $(UASDK_LIBS), $(eval $(call UA_template,$(lib))))
+endif
 
 INSTALL_BOOT =$(TOP)/iocBoot
 STCMD_INSTALLS = $(IOCS:%=$(INSTALL_BOOT)/ioc%/st.cmd)
@@ -33,14 +34,9 @@ Standard_DBD += iocshGlobalCommands.dbd
 OPCUAIOC_DBD += $(Standard_DBD)
 OPCUAIOC_DBD += opcUa.dbd
 
-OPCUAIOC_LIBS += $(EPICS_BASE_IOC_LIBS)
 OPCUAIOC_LIBS += opcUa
-OPCUAIOC_LIBS += uastack
-
-# set rpath than the libraries can be found at your install location
-# check path with: 'readelf -d ../bin/linux-x86_64/OPCUAIOC'
-#
-USR_LDFLAGS += '-Wl,-rpath,/home/kuner/tmp/testUa'
+OPCUAIOC_LIBS += $(UASDK_LIBS)
+OPCUAIOC_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 include $(TOP)/configure/RULES
 #----------------------------------------

--- a/testTop/testIocApp/Makefile
+++ b/testTop/testIocApp/Makefile
@@ -38,6 +38,8 @@ OPCUAIOC_LIBS += opcUa
 OPCUAIOC_LIBS += $(UASDK_LIBS)
 OPCUAIOC_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+OPCUAIOC_SYS_LIBS += xml2 crypto
+
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE


### PR DESCRIPTION
This is an attempt to clean up the handling of external libraries (in this case the SDK libs) by implementing the design roughly outlined in issue #3.

Users can select the mechanism between
- SYSTEM: libraries will be in a system location,
- PROVIDED: libraries will be in a configured location, and
- INSTALL: libraries will be copied into the support module.

No changes in code (except for a trivial fix in the test application).