### PR TITLE
Variable definitions for windows build

### DIFF
--- a/opcUaDevSupApp/devOpcUa.c
+++ b/opcUaDevSupApp/devOpcUa.c
@@ -412,9 +412,10 @@ long read_bi (struct biRecord* prec)
     OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
     int noOut = pOPCUA_ItemINFO->noOut;
     int udf   = prec->udf;
-	long ret = read((dbCommon*)prec);
+    long ret = 0;
 	
     epicsMutexLock(pOPCUA_ItemINFO->flagLock);
+    ret = read((dbCommon*)prec);
     if (!ret) {
         prec->rval = (pOPCUA_ItemINFO->varVal).UInt32;
         if(DEBUG_LEVEL >= 2) errlogPrintf("read_bi         %s %s RVAL:%d\n",prec->name,getTime(buf),prec->rval);
@@ -534,8 +535,10 @@ long read_stringin (struct stringinRecord* prec)
     OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
     int noOut = pOPCUA_ItemINFO->noOut;
     int udf   = prec->udf;
-    long ret = read((dbCommon*)prec);
-	epicsMutexLock(pOPCUA_ItemINFO->flagLock);
+    long ret = 0;
+
+    epicsMutexLock(pOPCUA_ItemINFO->flagLock);
+    ret = read((dbCommon*)prec);
     if( !ret ) {
         strncpy(prec->val,(pOPCUA_ItemINFO->varVal).cString,40);    // string length: see stringin.h
         prec->udf = FALSE;	// stringinRecord process doesn't set udf field in case of no convert!
@@ -594,13 +597,13 @@ long read_wf(struct waveformRecord *prec)
 {
     char buf[256];
     int udf   = prec->udf;
-	int ret = read((dbCommon*)prec);
-	OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
-	int noOut = pOPCUA_ItemINFO->noOut;
+    int ret = 0;
+    OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
+    int noOut = pOPCUA_ItemINFO->noOut;
     pOPCUA_ItemINFO->debug = prec->tpro;
     
     epicsMutexLock(pOPCUA_ItemINFO->flagLock);
-    
+    ret = read((dbCommon*)prec);
     if(! ret) {
         prec->nord = pOPCUA_ItemINFO->arraySize;
         pOPCUA_ItemINFO->arraySize = prec->nelm;
@@ -660,7 +663,7 @@ static long read(dbCommon * prec) {
 
 static long write(dbCommon *prec) {
     long ret = 0;
-	OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
+    OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
     pOPCUA_ItemINFO->debug = prec->tpro;
     
     if(DEBUG_LEVEL >= 3) errlogPrintf("\twrite()            UDF:%i, noOut=%i\n",prec->udf,pOPCUA_ItemINFO->noOut);

--- a/opcUaDevSupApp/devOpcUa.c
+++ b/opcUaDevSupApp/devOpcUa.c
@@ -412,9 +412,9 @@ long read_bi (struct biRecord* prec)
     OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
     int noOut = pOPCUA_ItemINFO->noOut;
     int udf   = prec->udf;
-
+	long ret = read((dbCommon*)prec);
+	
     epicsMutexLock(pOPCUA_ItemINFO->flagLock);
-    long ret = read((dbCommon*)prec);
     if (!ret) {
         prec->rval = (pOPCUA_ItemINFO->varVal).UInt32;
         if(DEBUG_LEVEL >= 2) errlogPrintf("read_bi         %s %s RVAL:%d\n",prec->name,getTime(buf),prec->rval);
@@ -534,8 +534,8 @@ long read_stringin (struct stringinRecord* prec)
     OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
     int noOut = pOPCUA_ItemINFO->noOut;
     int udf   = prec->udf;
-    epicsMutexLock(pOPCUA_ItemINFO->flagLock);
     long ret = read((dbCommon*)prec);
+	epicsMutexLock(pOPCUA_ItemINFO->flagLock);
     if( !ret ) {
         strncpy(prec->val,(pOPCUA_ItemINFO->varVal).cString,40);    // string length: see stringin.h
         prec->udf = FALSE;	// stringinRecord process doesn't set udf field in case of no convert!
@@ -593,13 +593,14 @@ long init_waveformRecord(struct waveformRecord* prec) {
 long read_wf(struct waveformRecord *prec)
 {
     char buf[256];
-    OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
-    pOPCUA_ItemINFO->debug = prec->tpro;
-    int noOut = pOPCUA_ItemINFO->noOut;
     int udf   = prec->udf;
-
+	int ret = read((dbCommon*)prec);
+	OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
+	int noOut = pOPCUA_ItemINFO->noOut;
+    pOPCUA_ItemINFO->debug = prec->tpro;
+    
     epicsMutexLock(pOPCUA_ItemINFO->flagLock);
-    int ret = read((dbCommon*)prec);
+    
     if(! ret) {
         prec->nord = pOPCUA_ItemINFO->arraySize;
         pOPCUA_ItemINFO->arraySize = prec->nelm;
@@ -658,10 +659,10 @@ static long read(dbCommon * prec) {
 }
 
 static long write(dbCommon *prec) {
-    OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
-    pOPCUA_ItemINFO->debug = prec->tpro;
     long ret = 0;
-
+	OPCUA_ItemINFO* pOPCUA_ItemINFO = (OPCUA_ItemINFO*)prec->dpvt;
+    pOPCUA_ItemINFO->debug = prec->tpro;
+    
     if(DEBUG_LEVEL >= 3) errlogPrintf("\twrite()            UDF:%i, noOut=%i\n",prec->udf,pOPCUA_ItemINFO->noOut);
 
     if(!pOPCUA_ItemINFO) {

--- a/opcUaDevSupApp/drvOpcUa.cpp
+++ b/opcUaDevSupApp/drvOpcUa.cpp
@@ -735,7 +735,7 @@ void print_OpcUa_DataValue(_OpcUa_DataValue *d)
 
 void printVal(UaVariant &val,OpcUa_UInt32 IdxUaItemInfo)
 {
-    int i;
+    OpcUa_UInt32 i;
     if(val.isArray()) {
         for(i=0;i<val.arraySize();i++) {
             if(UaVariant(val[i]).type() < OpcUaType_String)

--- a/testTop/testIocApp/Makefile
+++ b/testTop/testIocApp/Makefile
@@ -3,7 +3,7 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 
-DB = testServer.db freeopcuaTEST.db
+DB = testServer.db freeopcuaTEST.db OPCUA_RECORD.db
 
 IOCS += OPCUAIOC
 

--- a/testTop/testIocApp/OPCUA_RECORD.db
+++ b/testTop/testIocApp/OPCUA_RECORD.db
@@ -1,0 +1,78 @@
+record(ai,"REC:rdTemp"){
+#        field(SCAN,"1 second")
+        field(SCAN,"I/O Intr")
+#        field(PINI,"YES")
+        field(TSE, "-2")
+        field(DTYP,"OPCUA")
+        field(DISS,"INVALID")
+        field(INP,"@3:BuildingAutomation.AirConditioner_1.Temperature")
+        field(LINR,"SLOPE")
+        field(ASLO,"0.01")
+        field(AOFF,"0")
+}
+record(longin,"REC:rdTempINT"){
+#        field(SCAN,"1 second")
+        field(SCAN,"I/O Intr")
+        field(PINI,"YES")
+        field(TSE, "-2")
+        field(DTYP,"OPCUA")
+        field(DISS,"INVALID")
+        field(INP,"@3:BuildingAutomation.AirConditioner_1.Temperature")
+}
+record(ai,"REC:rdPwr"){
+#        field(SCAN,"1 second")
+        field(SCAN,"I/O Intr")
+        field(TSE, "-2")
+        field(PINI,"YES")
+        field(DTYP,"OPCUA")
+        field(DISS,"INVALID")
+        field(INP,"@3:BuildingAutomation.AirConditioner_1.PowerConsumption")
+}
+record(longin,"REC:rdSetTemp"){
+        field(DTYP,"OPCUA")
+#        field(SCAN,"1 second")
+        field(PINI,"YES")
+        field(SCAN,"I/O Intr")
+        field(DISS,"INVALID")
+        field(INP,"@3:BuildingAutomation.AirConditioner_1.TemperatureSetPoint")
+}
+record(ao,"REC:setTemp"){
+#        field(TSE, "-2")
+        field(DTYP,"OPCUA")
+        field(DISS,"INVALID")
+        field(OUT,"@3:BuildingAutomation.AirConditioner_1.TemperatureSetPoint")
+}
+record(longout,"REC:setTempInt"){
+#        field(TSE, "-2")
+        field(DTYP,"OPCUA")
+        field(DISS,"INVALID")
+        field(OUT,"@3:BuildingAutomation.AirConditioner_1.TemperatureSetPoint")
+}
+record(mbbiDirect,"REC:rdBit23"){
+        field(TSE, "-2")
+        field(DTYP,"OPCUA")
+#        field(SCAN,"5 second")
+        field(SCAN,"I/O Intr")
+        field(PINI,"YES")
+        field(INP,"@3:BuildingAutomation.AirConditioner_1.TemperatureSetPoint")
+        field(NOBT,"2")
+        field(SHFT,"2")
+}
+record(mbbi,"REC:stBit23"){
+#        field(SCAN,"5 second")
+        field(SCAN,"I/O Intr")
+        field(PINI,"YES")
+        field(TSE, "-2")
+        field(DTYP,"OPCUA")
+        field(INP,"@3:BuildingAutomation.AirConditioner_1.TemperatureSetPoint")
+        field(NOBT,"2")
+        field(SHFT,"1")
+        field(ZRVL,"0")
+        field(ONVL,"1")
+        field(TWVL,"2")
+        field(THVL,"3")
+        field(ZRST,"NULL")
+        field(ONST,"EINS")
+        field(TWST,"ZWEI")
+        field(THST,"DREI")
+}

--- a/testTop/testIocApp/st.cmd.OPCUAIOC
+++ b/testTop/testIocApp/st.cmd.OPCUAIOC
@@ -6,9 +6,10 @@ dbLoadDatabase "dbd/OPCUAIOC.dbd",0,0
 ${IOC}_registerRecordDeviceDriver pdbbase
 
 # hazel /home/kuner/Dokumente.BESSY/projects/opcProjekt/FREEOPCUA/freeOpcUaEpicsServer/bin/linux-x86_64/server
-drvOpcuaSetup("opc.tcp://localhost:4841","","hazel",0,0)
-dbLoadRecords("db/freeopcuaTEST.db")
+drvOpcuaSetup("opc.tcp://localhost:48010","","hazel",0,0)
+#dbLoadRecords("db/freeopcuaTEST.db")
 #dbLoadRecords("db/testServer.db")
+dbLoadRecords("db/OPCUA_RECORD.db")
 
 opcuaDebug(3)
 setIocLogDisable 1


### PR DESCRIPTION
Hi, sorry it took me long to test the merge. A minor thing was missed in devOpcUa.c aind drvOpcUa.cpp. Namely the variables need to be declared before definitions for VC to swallow it, and the counter used for UaVariant needs to be OpcUa type as well.

You can ignore changes to Makefile and st.cmd, I needed that because I am testing with UA demo server.