### PR TITLE
Configurable publishing/sampling rates, queue size and drop policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ EPICS OPC UA device support using the Unified Automation C++ based
 
 * Initial connection and reconnection are handled appropriately.
   The retry interval for the initial connection can be set using the variable
-  `connectInterval` (double), the default is 10.0 [sec].
+  `drvOpcua_AutoConnectInterval` (double), the default is 10.0 [sec].
 
 ## EPICS Database Examples:
 

--- a/README.md
+++ b/README.md
@@ -107,20 +107,32 @@ EPICS OPC UA device support using the Unified Automation C++ based
   (double), which defaults to 100.0 [ms].
 
 * Configurable sampling interval setting.
+  The sampling interval can be configured for each record by adding
+  an info item like
+     `info(opcua:SAMPLING, "100.0")`
+  with a double value in [ms].
   The default sampling interval setting [ms] for the OPC UA monitored items
   can be configured using the variable `drvOpcua_DefaultSamplingInterval`
   (double), which defaults to -1.0 (use publishing interval). Use a setting of
   0.0 for the fastest practical rate (server defined).
 
 * Configurable queue size setting.
+  The server side queue size can be configured for each record by adding
+  an info item like
+     `info(opcua:QSIZE, "10")`
+  with an unsigned integer value > 0.
   The default queue size setting for the OPC UA monitored items
   can be configured using the variable `drvOpcua_DefaultQueueSize` (integer),
   which defaults to 1 (no queueing).
 
 * Configurable discard policy setting.
-  The default discard policy for the OPC UA monitored items (in case of queue
-  overrun) can be configured to request discarding the oldest or the newest
-  value using the variable `drvOpcua_DefaultDiscardOldest` (integer),
+  The discard policy for the server side queue (in case of overrun) can be
+  configured for each record requesting  to discard the oldest or the newest
+  value by adding an info item like
+     `info(opcua:DISCARD, "new")`
+  with "old" (discard the oldest value) or "new" (discard the newest value).
+  The default discard policy can be configured using the variable
+  `drvOpcua_DefaultDiscardOldest` (integer),
   which defaults to 1 (discard the oldest value).
 
 ## EPICS Database Examples:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ EPICS OPC UA device support using the Unified Automation C++ based
   The retry interval for the initial connection can be set using the variable
   `drvOpcua_AutoConnectInterval` (double), the default is 10.0 [sec].
 
+* Configurable publish interval setting.
+  The default publish interval setting [ms] for the OPC UA subscriptions
+  can be configured using the variable `drvOpcua_DefaultPublishInterval`
+  (double), which defaults to 100.0 [ms].
+
+* Configurable sampling interval setting.
+  The default sampling interval setting [ms] for the OPC UA monitored items
+  can be configured using the variable `drvOpcua_DefaultSamplingInterval`
+  (double), which defaults to -1.0 (use publishing interval). Use a setting of
+  0.0 for the fastest practical rate (server defined).
+
+* Configurable queue size setting.
+  The default queue size setting for the OPC UA monitored items
+  can be configured using the variable `drvOpcua_DefaultQueueSize` (integer),
+  which defaults to 1 (no queueing).
+
+* Configurable discard policy setting.
+  The default discard policy for the OPC UA monitored items (in case of queue
+  overrun) can be configured to request discarding the oldest or the newest
+  value using the variable `drvOpcua_DefaultDiscardOldest` (integer),
+  which defaults to 1 (discard the oldest value).
+
 ## EPICS Database Examples:
 
 ```

--- a/opcUaDevSupApp/devOpcUa.h
+++ b/opcUaDevSupApp/devOpcUa.h
@@ -53,6 +53,10 @@ typedef struct OPCUA_Item {
 
     int isArray;
     int arraySize;
+                            /* OPC UA properties of the monitored item */
+    double samplingInterval;
+    epicsUInt32 queueSize;
+    unsigned char discardOldest;
 
     int debug;              // debug level of this item, defined in field REC:TPRO
     int stat;               /* Status of the opc connection */

--- a/opcUaDevSupApp/drvOpcUa.cpp
+++ b/opcUaDevSupApp/drvOpcUa.cpp
@@ -652,16 +652,27 @@ UaStatus DevUaClient::readFunc(UaDataValues &values,ServiceSettings &serviceSett
 void DevUaClient::itemStat(int verb)
 {
     errlogPrintf("OpcUa driver: Connected items: %lu\n", (unsigned long)vUaItemInfo.size());
-    if(verb>0) {
-        if(verb==1) errlogPrintf("Only bad signals\n");
-        errlogPrintf("idx record Name           epics Type         opcUa Type      Stat NS:PATH\n");
-        for(unsigned int i=0;i< vUaItemInfo.size();i++) {
+    if (verb > 0) {
+        if (verb == 1) errlogPrintf("Showing only bad signals\n");
+        if (verb > 2)
+            errlogPrintf("idx record Name           epics Type         opcUa Type      Stat Sampl QSiz Drop NS:PATH\n");
+        else
+            errlogPrintf("idx record Name           epics Type         opcUa Type      Stat NS:PATH\n");
+        for (unsigned int i=0; i< vUaItemInfo.size(); i++) {
             OPCUA_ItemINFO* uaItem = vUaItemInfo[i];
-            if((verb>1) || ((verb==1)&&(uaItem->stat==1)))  // verb=1 only the bad, verb>1 all
-                errlogPrintf("%3d %-20s %2d,%-15s %2d:%-15s %2d %s\n",uaItem->itemIdx,uaItem->prec->name,
+            if ((verb == 2) || ((verb == 1) && (uaItem->stat == 1)))  // verb == 1 only the bad, verb > 1 all
+                errlogPrintf("%3d %-20s %2d,%-15s %2d:%-15s %2d %s\n",
+                   uaItem->itemIdx,uaItem->prec->name,
                    uaItem->recDataType,epicsTypeNames[uaItem->recDataType],
                    uaItem->itemDataType,variantTypeStrings(uaItem->itemDataType),
                    uaItem->stat,uaItem->ItemPath );
+            else
+                errlogPrintf("%3d %-20s %2d,%-15s %2d:%-15s %2d %5g %4u %4s %s\n",
+                   uaItem->itemIdx,uaItem->prec->name,
+                   uaItem->recDataType,epicsTypeNames[uaItem->recDataType],
+                   uaItem->itemDataType,variantTypeStrings(uaItem->itemDataType),
+                   uaItem->stat, uaItem->samplingInterval, uaItem->queueSize,
+                   ( uaItem->discardOldest ? "old" : "new" ), uaItem->ItemPath );
         }
     }
 }

--- a/opcUaDevSupApp/drvOpcUa.cpp
+++ b/opcUaDevSupApp/drvOpcUa.cpp
@@ -192,9 +192,12 @@ private:
 void printVal(UaVariant &val,OpcUa_UInt32 IdxUaItemInfo);
 void print_OpcUa_DataValue(_OpcUa_DataValue *d);
 
-static double connectInterval = 10.0;
+// Configurable default for auto connection attempt interval
+
+static double drvOpcua_AutoConnectInterval = 10.0;
+
 extern "C" {
-    epicsExportAddress(double, connectInterval);
+    epicsExportAddress(double, drvOpcua_AutoConnectInterval);
 }
 
 // global variables
@@ -233,7 +236,7 @@ DevUaClient::DevUaClient(int autoCon=1,int debug=0)
     m_pDevUaSubscription  = new DevUaSubscription(getDebug());
     autoConnect = autoCon;
     if(autoConnect)
-        autoConnector     = new autoSessionConnect(this, connectInterval, queue);
+        autoConnector     = new autoSessionConnect(this, drvOpcua_AutoConnectInterval, queue);
 }
 
 DevUaClient::~DevUaClient()
@@ -1154,7 +1157,7 @@ long opcUa_init(UaString &g_serverUrl, UaString &g_applicationCertificate, UaStr
     status = pMyClient->connect();
     if(status.isBad()) {
         errlogPrintf("drvOpcuaSetup: Failed to connect to server '%s' - will retry every %f sec\n",
-                     g_serverUrl.toUtf8(), connectInterval);
+                     g_serverUrl.toUtf8(), drvOpcua_AutoConnectInterval);
         return 1;
     }
     // Create subscription

--- a/opcUaDevSupApp/opcUa.dbd
+++ b/opcUaDevSupApp/opcUa.dbd
@@ -21,4 +21,4 @@ function(OpcUaSetupMonitors)
 function(OpcUaWriteItems)
 function(opcUa_io_report)
 
-variable(connectInterval, double)
+variable(drvOpcua_AutoConnectInterval, double)

--- a/opcUaDevSupApp/opcUa.dbd
+++ b/opcUaDevSupApp/opcUa.dbd
@@ -22,3 +22,7 @@ function(OpcUaWriteItems)
 function(opcUa_io_report)
 
 variable(drvOpcua_AutoConnectInterval, double)
+variable(drvOpcua_DefaultPublishInterval, double)
+variable(drvOpcua_DefaultSamplingInterval, double)
+variable(drvOpcua_DefaultQueueSize)
+variable(drvOpcua_DefaultDiscardOldest)


### PR DESCRIPTION
This PR makes a bunch of properties configurable.

1. Publishing rate
This is a property of the subscription.
In the current state (only one subscription supported) the global setting of the default publishing rate is setting the rate for the single subscription.
Once multiple subscriptions are supported, the specific setting will be an argument of the iocShell call.

2. Sampling rate, queue size and dropping policy of server side queue
These are properties of the monitored item (i.e. per record).
The global default settings are used for all records without specific configuration.
Specific settings can be added to any OPCUA record through info items.

Using info items doesn't change behavior if a database does not specify them. This means the info item configuration mechanism is independent and will not interfere with other ways to configure these settings.